### PR TITLE
Fix bad request if there is no scope

### DIFF
--- a/Owin.Security.Strava/StravaAuthenticationHandler.cs
+++ b/Owin.Security.Strava/StravaAuthenticationHandler.cs
@@ -152,6 +152,9 @@ namespace Owin.Security.Strava
                 // OAuth2 10.12 CSRF
                 GenerateCorrelationId(extra);
 
+                if (Options.Scope.Count == 0)
+                    Options.Scope.Add("public"); // Bad request if there is no scope.
+                
                 // OAuth2 3.3 space separated
                 string scope = string.Join(" ", Options.Scope);
 


### PR DESCRIPTION
I've found that if I don't specify a scope Strava gives me the following error:

``` JSON
{
  "message": "Bad Request",
  "errors": [
    {
      "resource": "Authorize",
      "field": "scope",
      "code": "invalid"
    }
  ]
}
```

This patch addresses this issue by adding the scope _public_ as default.
